### PR TITLE
Fix CI errors for MacOS

### DIFF
--- a/include/enum_set/enum_set.hpp
+++ b/include/enum_set/enum_set.hpp
@@ -12,6 +12,13 @@ namespace enum_set
 namespace detail
 {
 
+/// Representation of a sequence of `Values...` of a certain `Type`.
+/// Used because `std::integer_sequence` does not work with enums on all platforms.
+template <typename Type, Type... Values>
+struct value_sequence
+{
+};
+
 /// Factory for `make_enum_sequence` meta function below.
 /// `Enum` must be of enumeration type.
 /// `Last` must be the last value of the `Enum` type.
@@ -30,7 +37,7 @@ struct enum_sequence_factory
         >;
 
     template <arithmetic_value_type... Values>
-    static std::integer_sequence<Enum, static_cast<Enum>(Values)...>
+    static value_sequence<Enum, static_cast<Enum>(Values)...>
     make_type(std::integer_sequence<arithmetic_value_type, Values...>);
 
     using type = decltype(make_type(make_arithmetic_sequence()));
@@ -56,7 +63,7 @@ struct enum_set_factory
 {
     template <Enum... Values>
     static value_set<Enum, Values...>
-    make_type(std::integer_sequence<Enum, Values...>);
+    make_type(detail::value_sequence<Enum, Values...>);
 
     using type = decltype(make_type(detail::make_enum_sequence<Enum, Last>()));
 };

--- a/include/enum_set/value_set_iterator.hpp
+++ b/include/enum_set/value_set_iterator.hpp
@@ -6,6 +6,9 @@
 #include <enum_set/standard_types.hpp>
 #include <enum_set/value_set.hpp>
 
+#include <algorithm>
+#include <iterator>
+
 namespace enum_set
 {
 namespace detail


### PR DESCRIPTION
  - Add missing includes
  - Replace std::integer_sequence with detail::value_sequence for enums
fixes #5 