### PR TITLE
Fix CI errors for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # cpp_enum_set
+
+![Build status](https://github.com/cdeln/cpp_enum_set/actions/workflows/ci.yml/badge.svg)
+[![GitHub release](https://img.shields.io/github/v/release/cdeln/cpp_enum_set)](https://github.com/cdeln/cpp_enum_set/releases)
+
 A library of type safe sets over fixed size collections of types or values,
 including methods for accessing, modifying, visiting and iterating over those.
 

--- a/include/enum_set/bit_mask.hpp
+++ b/include/enum_set/bit_mask.hpp
@@ -238,10 +238,8 @@ public:
     /// Specifying any invalid index throws an `std::out_of_range` exception.
     template <
         typename... Indices,
-        std::enable_if_t<
-            ! detail::any(std::is_same<Indices, bool>::value...),
-            nullptr_t
-        > = nullptr
+        bool Enable = ! detail::any(std::is_same<Indices, bool>::value...),
+        std::enable_if_t<Enable, nullptr_t> = nullptr
     >
     constexpr bit_mask(Indices... indices)
         : storage{}

--- a/include/enum_set/magic/magic_enum_set.hpp
+++ b/include/enum_set/magic/magic_enum_set.hpp
@@ -30,8 +30,10 @@ struct magic_enum_set_factory
     static constexpr auto indices = std::make_index_sequence<values.size()>();
 
     template <size_t... Indices>
-    static auto make_type(std::index_sequence<Indices...>) noexcept
-        -> value_set<Enum, values[Indices]...>;
+    static constexpr auto make_type(std::index_sequence<Indices...>) noexcept
+    {
+        return value_set<Enum, values[Indices]...>();
+    }
 
     using type = decltype(make_type(indices));
 };


### PR DESCRIPTION
  - Break up complex expression to help the compiler a bit

Fixes #6