### PR TITLE
Change testset type from size_t to int

### DIFF
--- a/test/test_iterator.cpp
+++ b/test/test_iterator.cpp
@@ -9,7 +9,7 @@
 
 using testset =
     ::enum_set::value_set<
-        size_t, 0, 2, 4, 6, 8, 1, 3, 5, 7, 9
+        int, 0, 2, 4, 6, 8, 1, 3, 5, 7, 9
     >;
 
 namespace


### PR DESCRIPTION
  - Fixes compile warnings on Windows